### PR TITLE
pull in first tag from managed attributes

### DIFF
--- a/product-feed.php
+++ b/product-feed.php
@@ -97,7 +97,12 @@ foreach ($products as $product)
 
   foreach ($customProductAttributes as $key) {
       $key = strtolower($key);
-      if(isset($productAttributes[$key]['options'][0])) {
+      if (isset($productAttributes[$key] && $productAttributes[$key]['is_taxonomy'])) {
+        // pull in product terms if key provided
+        $terms = wc_get_product_terms($product->ID. $key, ['fields' => 'names']);
+        $value = array_shift($terms);
+        $newFields[$key] = $value;
+      } elseif(isset($productAttributes[$key]['options'][0])) {
         $newFields[$key] = $productAttributes[$key]['options'][0];
       } elseif(isset($productAttributes[$key]) && is_string($productAttributes[$key])) {
         $newFields[$key] = $productAttributes[$key];


### PR DESCRIPTION
- Users can create and manage attributes in here - `/wp-admin/edit.php?post_type=product&page=product_attributes`
- The values for a given attribute can also be created and managed here.
- Any number of values can be assigned to the instance of attribute on a given product (like a multi-tag thing)

We can't currently pull those values in, it just pulls in the ID of that attribute. This update will pull the first added value for that product attribute.

resolves the use case for this client - https://trello.com/c/a26VOS3k/18601-uk-support-the-minifigure-store-gtin-feed-issues