### PR TITLE
Attempt to fetch Product instance from wc_get_product if $product fails.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Reviews, Seller Ratings, Google Reviews, Company Reviews, Stars in Adwords
 Author URI: https://www.reviews.io
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable Tag: 1.4.0
+Stable Tag: 1.4.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -68,6 +68,9 @@ Checkout the REVIEWS.io Changelog which outlines all of the feature updates & re
 
 
 == Changelog ==
+
+= 1.4.1 =
+* Fix - Fallback to wc_get_product if global $product variable is incorrect.
 
 = 1.4.0 =
 * Update - Add support to show default Reviews tab instead of Polaris.

--- a/woocommerce-reviews.php
+++ b/woocommerce-reviews.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
  * Author: Reviews.co.uk
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
- * Version: 1.4.0
+ * Version: 1.4.1
  *
  * WC requires at least: 3.0.0
  * WC tested up to: 8.0.3
@@ -41,7 +41,7 @@ add_action('before_woocommerce_init', 'declare_wc_compatibility');
  */
 function reviewsio_admin_scripts()
 {
-    $appVersion = '1.4.0';
+    $appVersion = '1.4.1';
     // Register scripts
     wp_enqueue_script('reviewsio-admin-script', plugins_url('/js/admin-script.js', __FILE__), [], $appVersion, false);
     wp_enqueue_script('reviewsio-widget-options-script', plugins_url('/js/widget-options-script.js', __FILE__), [], $appVersion, false);
@@ -84,7 +84,7 @@ if (!class_exists('WooCommerce_Reviews')) {
 
         protected $numWidgets = 0;
         protected $richsnippet_shortcode_url = '';
-        protected $appVersion = '1.4.0';
+        protected $appVersion = '1.4.1';
 
 
         public function __construct()
@@ -1168,24 +1168,33 @@ if (!class_exists('WooCommerce_Reviews')) {
               ');
             } else if ($product_enabled && !empty($skus) && is_product()) {
                 global $product;
+                $prod = $product; // We may alter this variable, so we create a copy as to not disturb global var $product.
+
+                if (!($prod instanceof WC_Product)) {
+                    $prod = wc_get_product(get_the_ID());
+                }
+
+                if (!($prod instanceof WC_Product)) {
+                    return;
+                }
 
                 $validUntil = gmdate('Y-m-d', strtotime('+30 days'));
 
-                $brand = $product->get_attribute('pa_brand');
+                $brand = $prod->get_attribute('pa_brand');
 
-                if ($product->is_type('variable')) {
-                    $variants = $product->get_available_variations();
+                if ($prod->is_type('variable')) {
+                    $variants = $prod->get_available_variations();
                 }
 
                 $offer = '{
                     "@type": "Offer",
                     "itemCondition": "NewCondition",
-                    "availability": " ' . esc_js($this->formatAvailability($product->get_stock_status())) . '",
-                    "price": "' . esc_js($product->get_price()) . '",
+                    "availability": " ' . esc_js($this->formatAvailability($prod->get_stock_status())) . '",
+                    "price": "' . esc_js($prod->get_price()) . '",
                     "priceCurrency": "' . esc_js(get_woocommerce_currency()) . '",
                     "sku": "' . esc_js($skus[0]) . '",
                     "priceValidUntil": "' . esc_js($validUntil) . '",
-                    "url": "' . esc_js(get_permalink($product->get_id())) . '",
+                    "url": "' . esc_js(get_permalink($prod->get_id())) . '",
                     "seller" : {
                         "@type": "Organization",
                         "name": "' . esc_js(get_bloginfo("name")) . '",
@@ -1203,8 +1212,8 @@ if (!class_exists('WooCommerce_Reviews')) {
                             "priceCurrency": "' . esc_js(get_woocommerce_currency()) . '",
                             "sku": "' . esc_js($variant['sku']) . '",
                             "priceValidUntil": "' . esc_js($validUntil) . '",
-                            "url": "' . esc_url(get_permalink($product->get_id())) . '",
-                            ' . wp_kses(apply_filters(('REVIEWSio_snippet-' . $variant['variation_id']), "", $product, $variant), []) . '
+                            "url": "' . esc_url(get_permalink($prod->get_id())) . '",
+                            ' . wp_kses(apply_filters(('REVIEWSio_snippet-' . $variant['variation_id']), "", $prod, $variant), []) . '
                             "seller" : {
                                 "@type": "Organization",
                                 "name": "' . esc_js(htmlspecialchars(get_bloginfo("name"))) . '",
@@ -1214,17 +1223,17 @@ if (!class_exists('WooCommerce_Reviews')) {
                     }
                 }
 
-                $image = wp_get_attachment_image_src(get_post_thumbnail_id($product->get_id()), 'single-post-thumbnail');
+                $image = wp_get_attachment_image_src(get_post_thumbnail_id($prod->get_id()), 'single-post-thumbnail');
                 if (get_option('REVIEWSio_enable_product_rich_snippet_server_side')) {
                     $baseData = [
                         "@context" => "http://schema.org",
                         "@type" => "Product",
-                        "name" => esc_js(htmlspecialchars($product->get_name())),
+                        "name" => esc_js(htmlspecialchars($prod->get_name())),
                         "image" => esc_js($image[0] ?? ''),
-                        "description" => wp_json_encode(apply_filters('REVIEWSio_description', htmlspecialchars(wp_strip_all_tags($product->get_description())), $product)),
+                        "description" => wp_json_encode(apply_filters('REVIEWSio_description', htmlspecialchars(wp_strip_all_tags($prod->get_description())), $prod)),
                         "brand" => [
                             "@type" => "Brand",
-                            "name: " => apply_filters('REVIEWSio_brand', (htmlspecialchars(!empty($brand) ? esc_js($brand) : esc_js(get_bloginfo("name")))), $product)
+                            "name: " => apply_filters('REVIEWSio_brand', (htmlspecialchars(!empty($brand) ? esc_js($brand) : esc_js(get_bloginfo("name")))), $prod)
                         ],
                         "offers" => [json_decode('[' . rtrim(wp_kses($offer, []), ',') . ']')]
                     ];
@@ -1243,14 +1252,14 @@ if (!class_exists('WooCommerce_Reviews')) {
                         data:{
                             "@context": "http://schema.org",
                             "@type": "Product",
-                            "name": "' . esc_js(htmlspecialchars($product->get_name())) . '",
+                            "name": "' . esc_js(htmlspecialchars($prod->get_name())) . '",
                             image: "' . (esc_js($image[0] ?? "")) . '",
-                            description: ' . wp_json_encode(apply_filters('REVIEWSio_description', htmlspecialchars(wp_strip_all_tags($product->get_description())), $product)) . ',
+                            description: ' . wp_json_encode(apply_filters('REVIEWSio_description', htmlspecialchars(wp_strip_all_tags($prod->get_description())), $prod)) . ',
                             brand: {
                             "@type": "Brand",
-                            name: "' . wp_kses(apply_filters('REVIEWSio_brand', (htmlspecialchars(!empty($brand) ? esc_js($brand) : esc_js(get_bloginfo("name")))), $product), []) . '"
+                            name: "' . wp_kses(apply_filters('REVIEWSio_brand', (htmlspecialchars(!empty($brand) ? esc_js($brand) : esc_js(get_bloginfo("name")))), $prod), []) . '"
                             },
-                            ' . wp_kses(apply_filters('REVIEWSio_snippet', "", $product), []) . '
+                            ' . wp_kses(apply_filters('REVIEWSio_snippet', "", $prod), []) . '
                             offers: [' . ($offer) . ']
                         }
                     });

--- a/woocommerce-reviews.php
+++ b/woocommerce-reviews.php
@@ -1170,7 +1170,6 @@ if (!class_exists('WooCommerce_Reviews')) {
                 global $product;
                 $prod = $product; // We may alter this variable, so we create a copy as to not disturb global var $product.
 
-
                 if (!is_object($prod)) {
                     $prod = wc_get_product(get_the_ID());
                 }

--- a/woocommerce-reviews.php
+++ b/woocommerce-reviews.php
@@ -1170,11 +1170,12 @@ if (!class_exists('WooCommerce_Reviews')) {
                 global $product;
                 $prod = $product; // We may alter this variable, so we create a copy as to not disturb global var $product.
 
-                if (!($prod instanceof WC_Product)) {
+
+                if (!is_object($prod)) {
                     $prod = wc_get_product(get_the_ID());
                 }
 
-                if (!($prod instanceof WC_Product)) {
+                if (!is_object($prod)) {
                     return;
                 }
 

--- a/woocommerce-reviews.php
+++ b/woocommerce-reviews.php
@@ -1168,6 +1168,11 @@ if (!class_exists('WooCommerce_Reviews')) {
               ');
             } else if ($product_enabled && !empty($skus) && is_product()) {
                 $prod = $this->getProduct();
+
+                if (empty($prod)) {
+                    return;
+                }
+
                 $validUntil = gmdate('Y-m-d', strtotime('+30 days'));
 
                 $brand = $prod->get_attribute('pa_brand');


### PR DESCRIPTION
There is a client where `$product` is a string and not a WC_Product object. This PR attempts to resolve this by using `wc_get_product` as a fallback resource if `$product` fails.

`$product` is copied to the `$prod` variable so that we ourselves don't many any changes to the `$product` global variable.