### PR TITLE
[REVIEWS-1789] Remove cron warnings

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Reviews, Seller Ratings, Google Reviews, Company Reviews, Stars in Adwords
 Author URI: https://www.reviews.io
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable Tag: 1.5.2
+Stable Tag: 1.5.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -68,6 +68,9 @@ Checkout the REVIEWS.io Changelog which outlines all of the feature updates & re
 
 
 == Changelog ==
+
+= 1.5.3 =
+* Fix - Prevent occasional PHP warnings during scheduled tasks (wp-cron) by setting request checks in admin.
 
 = 1.5.2 =
 * Fix - Fixed a bug related to not accepting certain values in Invitation Recency limit.

--- a/woocommerce-reviews.php
+++ b/woocommerce-reviews.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
  * Author: Reviews.co.uk
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
- * Version: 1.5.2
+ * Version: 1.5.3
  *
  * WC requires at least: 3.0.0
  * WC tested up to: 8.0.3
@@ -41,7 +41,7 @@ add_action('before_woocommerce_init', 'declare_wc_compatibility');
  */
 function reviewsio_admin_scripts()
 {
-    $appVersion = '1.5.2';
+    $appVersion = '1.5.3';
     // Register scripts
     wp_enqueue_script('reviewsio-admin-script', plugins_url('/js/admin-script.js', __FILE__), [], $appVersion, false);
     wp_enqueue_script('reviewsio-widget-options-script', plugins_url('/js/widget-options-script.js', __FILE__), [], $appVersion, false);

--- a/woocommerce-reviews.php
+++ b/woocommerce-reviews.php
@@ -1894,9 +1894,12 @@ if (!class_exists('WooCommerce_Reviews')) {
                 add_action('elementor/widgets/register', array('ElementorFunctions', 'unregister_widgets'));
             }
 
-            if ($_SERVER['REQUEST_METHOD'] === 'GET' && (!isset($_GET['_wpnonce']) || !wp_verify_nonce($_GET['_wpnonce'], 'reviewscouk_menu_nonce'))) {
-                //wp_die('Nonce verification failed.');
+            if (is_admin() && isset($_GET['page']) && trim($_GET['page']) === 'reviewscouk') {
+                if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'GET' && (!isset($_GET['_wpnonce']) || !wp_verify_nonce($_GET['_wpnonce'], 'reviewscouk_menu_nonce'))) {
+                    //wp_die('Nonce verification failed.');
+                }
             }
+
             if (isset($_GET["page"]) && trim($_GET["page"]) == 'reviewscouk') {
                 add_action('admin_enqueue_scripts', 'reviewsio_admin_scripts');
             }


### PR DESCRIPTION
Ensure `$_SERVER['REQUEST_METHOD']` only runs on a valid page.