### PR TITLE
[REVIEWS-3602] Fix cron corrupting refund records into shop_order

### DIFF
--- a/includes/order_csv.php
+++ b/includes/order_csv.php
@@ -22,6 +22,11 @@ function get_order_details($o)
 
     if ($using_hpos) {
         $order = wc_get_order($o->get_id());
+
+        if (!$order) {
+            return null;
+        }
+
         $order_data = $order->get_data();
 
         $order_id = $order->get_id();
@@ -29,6 +34,11 @@ function get_order_details($o)
         $email = $order_data['billing']['email'];
     } else {
         $order = wc_get_order($o->ID);
+
+        if (!$order) {
+            return null;
+        }
+
         $order_id  = $order->get_order_number();
         $firstname = $order->get_billing_first_name() . ' ' . $order->get_billing_last_name();
         $email = $order->get_billing_email();
@@ -69,6 +79,10 @@ if ($using_hpos) {
 
 foreach ($orders as $o) {
     $order_details = get_order_details($o);
+
+    if (!$order_details) {
+        continue;
+    }
 
     $order = $order_details->order;
     $order_id = $order_details->order_id;

--- a/includes/order_csv.php
+++ b/includes/order_csv.php
@@ -21,14 +21,14 @@ function get_order_details($o)
     $using_hpos = is_hpos_enabled();
 
     if ($using_hpos) {
-        $order = new WC_Order($o->get_id());
+        $order = wc_get_order($o->get_id());
         $order_data = $order->get_data();
 
         $order_id = $order->get_id();
         $firstname = $order_data['billing']['first_name'] . ' ' . $order_data['billing']['last_name'];
         $email = $order_data['billing']['email'];
     } else {
-        $order = new WC_Order($o->ID);
+        $order = wc_get_order($o->ID);
         $order_id  = $order->get_order_number();
         $firstname = $order->get_billing_first_name() . ' ' . $order->get_billing_last_name();
         $email = $order->get_billing_email();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Reviews, Seller Ratings, Google Reviews, Company Reviews, Stars in Adwords
 Author URI: https://www.reviews.io
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable Tag: 1.5.5
+Stable Tag: 1.5.6
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -68,6 +68,9 @@ Checkout the REVIEWS.io Changelog which outlines all of the feature updates & re
 
 
 == Changelog ==
+= 1.5.6 =
+* Fix - Prevent cron from corrupting refund records into shop_order when HPOS is enabled.
+
 = 1.5.5 =
 * Fix - Rollback product feed changes.
 

--- a/woocommerce-reviews.php
+++ b/woocommerce-reviews.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
  * Author: Reviews.co.uk
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
- * Version: 1.5.5
+ * Version: 1.5.6
  *
  * WC requires at least: 3.0.0
  * WC tested up to: 8.0.3
@@ -41,7 +41,7 @@ add_action('before_woocommerce_init', 'declare_wc_compatibility');
  */
 function reviewsio_admin_scripts()
 {
-    $appVersion = '1.5.5';
+    $appVersion = '1.5.6';
     // Register scripts
     wp_enqueue_script('reviewsio-admin-script', plugins_url('/js/admin-script.js', __FILE__), [], $appVersion, false);
     wp_enqueue_script('reviewsio-widget-options-script', plugins_url('/js/widget-options-script.js', __FILE__), [], $appVersion, false);
@@ -85,7 +85,7 @@ if (!class_exists('WooCommerce_Reviews')) {
 
         protected $numWidgets = 0;
         protected $richsnippet_shortcode_url = '';
-        protected $appVersion = '1.5.5';
+        protected $appVersion = '1.5.6';
 
 
         public function __construct()

--- a/woocommerce-reviews.php
+++ b/woocommerce-reviews.php
@@ -423,7 +423,8 @@ if (!class_exists('WooCommerce_Reviews')) {
                 }
 
                 foreach ($orders as $order) {
-                    $this->processCompletedOrder($order->get_id());
+                    $order_id = $this->is_hpos_enabled() ? $order->get_id() : $order->ID;
+                    $this->processCompletedOrder($order_id);
                 }
             }
         }
@@ -445,6 +446,11 @@ if (!class_exists('WooCommerce_Reviews')) {
         {
             $api_url = $this->getApiDomain();
             $order   = wc_get_order($order_id);
+
+            if (!$order) {
+                return;
+            }
+
             $items   = $order->get_items();
 
             if ($this->is_hpos_enabled()) {

--- a/woocommerce-reviews.php
+++ b/woocommerce-reviews.php
@@ -396,7 +396,7 @@ if (!class_exists('WooCommerce_Reviews')) {
                             'limit'        => 30,
                             'meta_key'     => '_reviewscouk_status',
                             'meta_compare' => 'NOT EXISTS',
-                            'type'         => wc_get_order_types(),
+                            'type'         => array_diff(wc_get_order_types(), ['shop_order_refund']),
                             'status'       => array('wc-completed'),
                             'date_created' => '>' . gmdate('Y-m-d', strtotime("-{$offset_days} days")),
                         ));
@@ -405,7 +405,7 @@ if (!class_exists('WooCommerce_Reviews')) {
                             'limit'        => 30,
                             'meta_key'     => '_reviewscouk_status',
                             'meta_compare' => 'NOT EXISTS',
-                            'type'         => wc_get_order_types(),
+                            'type'         => array_diff(wc_get_order_types(), ['shop_order_refund']),
                             'status'       => array('wc-completed'),
                         ));
                     }
@@ -414,7 +414,7 @@ if (!class_exists('WooCommerce_Reviews')) {
                         'numberposts'  => 30,
                         'meta_key'     => '_reviewscouk_status',
                         'meta_compare' => 'NOT EXISTS',
-                        'post_type'    => wc_get_order_types(),
+                        'post_type'    => array_diff(wc_get_order_types(), ['shop_order_refund']),
                         'post_status'  => array('wc-completed'),
                         'date_query'   => array(
                             'after' => gmdate('Y-m-d', strtotime('-5 days')),
@@ -423,7 +423,7 @@ if (!class_exists('WooCommerce_Reviews')) {
                 }
 
                 foreach ($orders as $order) {
-                    $this->processCompletedOrder($order->ID);
+                    $this->processCompletedOrder($order->get_id());
                 }
             }
         }
@@ -444,7 +444,7 @@ if (!class_exists('WooCommerce_Reviews')) {
         public function processCompletedOrder($order_id)
         {
             $api_url = $this->getApiDomain();
-            $order   = new WC_Order($order_id);
+            $order   = wc_get_order($order_id);
             $items   = $order->get_items();
 
             if ($this->is_hpos_enabled()) {

--- a/woocommerce-reviews.php
+++ b/woocommerce-reviews.php
@@ -396,7 +396,7 @@ if (!class_exists('WooCommerce_Reviews')) {
                             'limit'        => 30,
                             'meta_key'     => '_reviewscouk_status',
                             'meta_compare' => 'NOT EXISTS',
-                            'type'         => array_diff(wc_get_order_types(), ['shop_order_refund']),
+                            'type'         => array_diff(wc_get_order_types(), ['shop_order_refund', 'shop_order_placehold']),
                             'status'       => array('wc-completed'),
                             'date_created' => '>' . gmdate('Y-m-d', strtotime("-{$offset_days} days")),
                         ));
@@ -405,7 +405,7 @@ if (!class_exists('WooCommerce_Reviews')) {
                             'limit'        => 30,
                             'meta_key'     => '_reviewscouk_status',
                             'meta_compare' => 'NOT EXISTS',
-                            'type'         => array_diff(wc_get_order_types(), ['shop_order_refund']),
+                            'type'         => array_diff(wc_get_order_types(), ['shop_order_refund', 'shop_order_placehold']),
                             'status'       => array('wc-completed'),
                         ));
                     }
@@ -414,7 +414,7 @@ if (!class_exists('WooCommerce_Reviews')) {
                         'numberposts'  => 30,
                         'meta_key'     => '_reviewscouk_status',
                         'meta_compare' => 'NOT EXISTS',
-                        'post_type'    => array_diff(wc_get_order_types(), ['shop_order_refund']),
+                        'post_type'    => array_diff(wc_get_order_types(), ['shop_order_refund', 'shop_order_placehold']),
                         'post_status'  => array('wc-completed'),
                         'date_query'   => array(
                             'after' => gmdate('Y-m-d', strtotime('-5 days')),


### PR DESCRIPTION
The hourly cron was querying wc_get_order_types() which includes shop_order_refund, then passing refund IDs through new WC_Order() and save(), permanently overwriting their type to shop_order.

- Exclude shop_order_refund from cron order queries
- Replace new WC_Order() with wc_get_order() for correct class resolution
- Use $order->get_id() instead of $order->ID for HPOS compatibility